### PR TITLE
fix: add stdout to errBuf, make synchronous

### DIFF
--- a/tfexec/cmd_linux.go
+++ b/tfexec/cmd_linux.go
@@ -2,16 +2,32 @@ package tfexec
 
 import (
 	"context"
+	"io"
 	"os/exec"
 	"strings"
+	"sync"
 	"syscall"
 )
 
+// syncWriter is an io.Writer protected by a sync.Mutex.
+type syncWriter struct {
+	sync.Mutex
+	w io.Writer
+}
+
+// Write implements io.Writer.
+func (w *syncWriter) Write(p []byte) (int, error) {
+	w.Lock()
+	defer w.Unlock()
+	return w.w.Write(p)
+}
+
 func (tf *Terraform) runTerraformCmd(ctx context.Context, cmd *exec.Cmd) error {
 	var errBuf strings.Builder
-
-	cmd.Stdout = mergeWriters(cmd.Stdout, tf.stdout)
-	cmd.Stderr = mergeWriters(cmd.Stderr, tf.stderr, &errBuf)
+	// ensure we don't mix up stdout and stderr
+	sw := &syncWriter{w: &errBuf}
+	cmd.Stdout = mergeWriters(cmd.Stdout, tf.stdout, sw)
+	cmd.Stderr = mergeWriters(cmd.Stderr, tf.stderr, sw)
 
 	cmd.SysProcAttr = &syscall.SysProcAttr{
 		// kill children if parent is dead


### PR DESCRIPTION
To provide additional debugging information for the Terraform provisioner, adding the Terraform stdout to the error output returned. 

Ref: https://github.com/coder/coder/issues/1198